### PR TITLE
[Feature] Validar horários da agenda

### DIFF
--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/event/utils/ScheduleUtil.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/event/utils/ScheduleUtil.java
@@ -2,10 +2,7 @@ package school.sptech.conmusicapi.modules.event.utils;
 
 import school.sptech.conmusicapi.modules.event.dtos.CreateScheduleDto;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.LocalDate;
+import java.time.*;
 
 public class ScheduleUtil {
     private static Boolean isSchedulesValid(CreateScheduleDto schedule1, CreateScheduleDto schedule2) {
@@ -49,6 +46,7 @@ public class ScheduleUtil {
 
             if (
                     inicioShow2.isAfter(fimShow1)
+                    && Duration.between(fimShow1, inicioShow2).toMinutes() >= 10
             ) {
                 result = true;
             }


### PR DESCRIPTION
## Por que foi feito?
Era preciso garantir que horários da agenda não estivessem sobrepostos e que houvesse 10 minutos de intervalo entre um horário e outro
....
## O que foi feito?
Foi criado um utilitário para garantir as validações necessárias para horários de uma agenda
....