### PR TITLE
[Bug] Evento recursivo com estabelecimento

### DIFF
--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/artist/services/ArtistService.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/artist/services/ArtistService.java
@@ -129,7 +129,7 @@ public class ArtistService {
                 () -> new UserForbiddenActionException("The user does not have permission to register genre for this user.")
         );
 
-        Genre genre = genreRepository.findByName(nameGenre).orElseThrow(
+        Genre genre = genreRepository.findByNameIgnoreCase(nameGenre).orElseThrow(
                 () -> new EntityNotFoundException(String.format("Gender with name %s was not found", nameGenre))
         );
 
@@ -151,7 +151,7 @@ public class ArtistService {
 //                () -> new UserForbiddenActionException("The user does not have permission to register genre for this user.")
 //        );
 
-        Genre genre = genreRepository.findByName(nameGenre).orElseThrow(
+        Genre genre = genreRepository.findByNameIgnoreCase(nameGenre).orElseThrow(
                 () -> new EntityNotFoundException(String.format("Gender with name %s was not found", nameGenre))
         );
 

--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/dtos/EventDto.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/dtos/EventDto.java
@@ -1,6 +1,6 @@
 package school.sptech.conmusicapi.modules.events.dtos;
 
-import school.sptech.conmusicapi.modules.establishment.dtos.EstablishmentDto;
+import school.sptech.conmusicapi.modules.establishment.dtos.DisplayScheduleEstablishmentDto;
 import school.sptech.conmusicapi.modules.genre.dto.DisplayingGenreDto;
 import school.sptech.conmusicapi.modules.schedules.dtos.BasicScheduleDto;
 
@@ -12,7 +12,7 @@ public class EventDto {
     private String description;
     private Double value;
     private Double coverCharge;
-    private EstablishmentDto establishment;
+    private DisplayScheduleEstablishmentDto establishment;
     private DisplayingGenreDto genre;
     private List<BasicScheduleDto> schedules;
 
@@ -56,11 +56,11 @@ public class EventDto {
         this.coverCharge = coverCharge;
     }
 
-    public EstablishmentDto getEstablishment() {
+    public DisplayScheduleEstablishmentDto getEstablishment() {
         return establishment;
     }
 
-    public void setEstablishment(EstablishmentDto establishment) {
+    public void setEstablishment(DisplayScheduleEstablishmentDto establishment) {
         this.establishment = establishment;
     }
 

--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/mappers/EventMapper.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/mappers/EventMapper.java
@@ -29,7 +29,7 @@ public class EventMapper {
         dto.setDescription(entity.getDescription());
         dto.setValue(entity.getValue());
         dto.setCoverCharge(entity.getCoverCharge());
-        dto.setEstablishment(EstablishmentMapper.toDto(entity.getEstablishment()));
+        dto.setEstablishment(EstablishmentMapper.toDisplayScheduleEstablishmentDto(entity.getEstablishment()));
         dto.setGenre(GenreMapper.toDto(entity.getGenre()));
         dto.setSchedules(entity.getSchedules().stream().map(ScheduleMapper::toBasicDto).toList());
 

--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/services/EventService.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/events/services/EventService.java
@@ -14,7 +14,6 @@ import school.sptech.conmusicapi.modules.genre.repository.IGenreRepository;
 import school.sptech.conmusicapi.shared.exceptions.BusinessRuleException;
 import school.sptech.conmusicapi.shared.exceptions.EntityNotFoundException;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -36,7 +35,7 @@ public class EventService {
             throw new EntityNotFoundException(String.format("Establishment with id %d was not found", dto.getEstablishmentId()));
         }
 
-        Optional<Genre> genre = genreRepository.findByName(dto.getGenre());
+        Optional<Genre> genre = genreRepository.findByNameIgnoreCase(dto.getGenre());
 
         if (genre.isEmpty()) {
             throw new EntityNotFoundException(String.format("Genre with name %s was not found", dto.getGenre()));

--- a/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/genre/repository/IGenreRepository.java
+++ b/conmusic-api/src/main/java/school/sptech/conmusicapi/modules/genre/repository/IGenreRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface IGenreRepository extends JpaRepository<Genre, Integer> {
 
-    Optional<Genre> findByName(String name);
+    Optional<Genre> findByNameIgnoreCase(String name);
 }


### PR DESCRIPTION
## Por que foi feito?
Nos endpoints de evento, ao retornar o evento o estabelecimento acabava mapeando a lista de eventos que ele possue o que causava uma recursiva desnecessária
....
## O que foi feito?
O mapeamento do estabelcimento está sendo feito por outra classe para evitar a recursividade
....